### PR TITLE
update zshrc: open tab in current directory

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -43,3 +43,5 @@ export TF_CPP_MIN_LOG_LEVEL=2
 
 
 # source /opt/ros/kinetic/setup.zsh
+# open new tab in current directory
+[[ -f /etc/profile.d/vte-2.91.sh ]] && . /etc/profile.d/vte-2.91.sh


### PR DESCRIPTION
I added a fix to zshrc to open tab in current directory. The  version vte-2.91.sh is specific to my Ubuntu dist. Should we make it more general?